### PR TITLE
✨ feat: support inject newResourceLock for manager.Options

### DIFF
--- a/pkg/manager/options.go
+++ b/pkg/manager/options.go
@@ -1,0 +1,34 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package manager
+
+import (
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/leaderelection/resourcelock"
+	"sigs.k8s.io/controller-runtime/pkg/leaderelection"
+	"sigs.k8s.io/controller-runtime/pkg/recorder"
+)
+
+// SetNewResourceLock set a new resource lock function
+//
+// Allow this private field to be set in other packages
+// You can insert your own leader election logic
+func (opt *Options) SetNewResourceLock(
+	newResourceLock func(config *rest.Config, recorderProvider recorder.Provider, options leaderelection.Options) (
+		resourcelock.Interface, error)) {
+	opt.newResourceLock = newResourceLock
+}


### PR DESCRIPTION
We need to insert some leadership election logic.
For example, disaster recovery related.

<!-- please add an icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles:, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🌱 (:seedling:, other) -->

<!-- What does this do, and why do we need it? -->
