### PR TITLE
cherry pick #3 #2

### DIFF
--- a/pkg/client/apiutil/dynamicrestmapper_test.go
+++ b/pkg/client/apiutil/dynamicrestmapper_test.go
@@ -1,19 +1,3 @@
-/*
-Copyright 2021 The Kubernetes Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
-
 package apiutil
 
 import (

--- a/pkg/manager/options.go
+++ b/pkg/manager/options.go
@@ -1,0 +1,34 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package manager
+
+import (
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/leaderelection/resourcelock"
+	"sigs.k8s.io/controller-runtime/pkg/leaderelection"
+	"sigs.k8s.io/controller-runtime/pkg/recorder"
+)
+
+// SetNewResourceLock set a new resource lock function
+//
+// Allow this private field to be set in other packages
+// You can insert your own leader election logic
+func (opt *Options) SetNewResourceLock(
+	newResourceLock func(config *rest.Config, recorderProvider recorder.Provider, options leaderelection.Options) (
+		resourcelock.Interface, error)) {
+	opt.newResourceLock = newResourceLock
+}


### PR DESCRIPTION
we update katanomi controller to 0.14.1 , so we should cherry-pick all our changes

cherry-pick https://github.com/katanomi/controller-runtime/pull/3
cherry-pick https://github.com/katanomi/controller-runtime/pull/2

<!-- What does this do, and why do we need it? -->
